### PR TITLE
Fix panic when vat validation service (VIES) is down

### DIFF
--- a/numbers.go
+++ b/numbers.go
@@ -88,7 +88,10 @@ func ValidateNumberFormat(n string) (bool, error) {
 // ValidateNumberExistence validates a VAT number by its existence using the VIES VAT API (using SOAP)
 func ValidateNumberExistence(n string) (bool, error) {
 	r, err := checkVAT(n)
-	return r.Valid, err
+	if err != nil {
+		return false, err
+	}
+	return r.Valid, nil
 }
 
 // checkVAT returns *ViesResponse for a VAT number


### PR DESCRIPTION
Hi @dannyvankooten, I was using this library to validate around 5k VAT numbers, when I noticed that `VIES` was not available during some of those requests, causing the library to throw a `panic`as follows: 

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x30 pc=0x1219f94]

goroutine 1 [running]:
github.com/dannyvankooten/vat.ValidateNumberExistence(0xc42011b3f2, 0xd, 0xc420281d01, 0x0, 0x0)
	/Users/marceloton/go/src/github.com/dannyvankooten/vat/numbers.go:91 +0x44
github.com/dannyvankooten/vat.ValidateNumber(0xc42011b3f2, 0xd, 0x2, 0x2, 0x2)
	/Users/marceloton/go/src/github.com/dannyvankooten/vat/numbers.go:35 +0x84
main.isValid(0xc42011b3f2, 0xd, 0x2)
```

The main issue here is that `ValidateNumberExistence` is always returning `r.Valid`, but `r` is the result of  `checkVAT` method, which can be `nil` in multiple scenarios.

I didn't add any tests for covering this scenario because the way it is structured it's not super easy to mock that behaviour, but I guess that can be left as a future improvement. What do you think?