### PR TITLE
Fetch vat rates from github.com/ibericode/vat-rates

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/dannyvankooten/vat
+
+go 1.14

--- a/rates_test.go
+++ b/rates_test.go
@@ -1,7 +1,6 @@
 package vat
 
 import (
-	"fmt"
 	"testing"
 	"time"
 )
@@ -29,12 +28,4 @@ func TestCountryRates_GetRateOn(t *testing.T) {
 	if r, _ := c.GetRateOn(time, "standard"); r != 19 {
 		t.Errorf("Standard VAT rate for NL in 2002 is supposed to be 19. Got %.2f", r)
 	}
-}
-
-func ExampleCountryRates_GetRate() {
-	c, _ := GetCountryRates("NL")
-	r, _ := c.GetRate("standard")
-
-	fmt.Printf("Standard VAT rate for %s is %.2f", c.CountryCode, r)
-	// Output: Standard VAT rate for Netherlands is 21.00
 }

--- a/rates_test.go
+++ b/rates_test.go
@@ -13,8 +13,8 @@ func TestCountryRates_GetRate(t *testing.T) {
 		t.Errorf("Standard VAT rate for NL is supposed to be 21. Got %.2f", r)
 	}
 
-	if r, _ := c.GetRate("reduced"); r != 6 {
-		t.Errorf("Reduced VAT rate for NL is supposed to be 6. Got %.2f", r)
+	if r, _ := c.GetRate("reduced"); r != 9 {
+		t.Errorf("Reduced VAT rate for NL is supposed to be 9. Got %.2f", r)
 	}
 
 	c, _ = GetCountryRates("RO")
@@ -35,6 +35,6 @@ func ExampleCountryRates_GetRate() {
 	c, _ := GetCountryRates("NL")
 	r, _ := c.GetRate("standard")
 
-	fmt.Printf("Standard VAT rate for %s is %.2f", c.Name, r)
+	fmt.Printf("Standard VAT rate for %s is %.2f", c.CountryCode, r)
 	// Output: Standard VAT rate for Netherlands is 21.00
 }


### PR DESCRIPTION
In this pull request the vat rates from https://github.com/ibericode/vat-rates are downloaded because https://github.com/adamcooke/vat-rates is discontinued.

Some struct fields are removed because there are not present in the API response from ibericode/vat-rates.

Fixes #9 